### PR TITLE
Only enable [flickr video] shortcode in WP < 4.4

### DIFF
--- a/vipers-video-quicktags.php
+++ b/vipers-video-quicktags.php
@@ -298,7 +298,11 @@ class VipersVideoQuicktags {
 		add_shortcode( 'metacafe', array(&$this, 'shortcode_metacafe') );
 		add_shortcode( 'blip.tv', array(&$this, 'shortcode_bliptv') );
 		add_shortcode( 'bliptv', array(&$this, 'shortcode_bliptv') ); // Not the preferred format
-		add_shortcode( 'flickr video', array(&$this, 'shortcode_flickrvideo') ); // WordPress.com
+		
+		// Spaces are invalid shortcode characters in WP 4.4
+		if ( get_bloginfo('version') < 4.4 )
+			add_shortcode( 'flickr video', array(&$this, 'shortcode_flickrvideo') ); // WordPress.com
+			
 		add_shortcode( 'flickrvideo', array(&$this, 'shortcode_flickrvideo') ); // Normal format
 		add_shortcode( 'ifilm', array(&$this, 'shortcode_ifilm') );
 		add_shortcode( 'spike', array(&$this, 'shortcode_ifilm') );


### PR DESCRIPTION
In WP 4.4, spaces are disallowed characters in shortcode names.

This change adds the `[flickr video]` shortcode only if the current WordPress install version is less than 4.4.
